### PR TITLE
Include Codecov

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,10 @@ jobs:
           java-package: jdk+fx
 
       - name: Build and check with Gradle
-        run: ./gradlew check
+        run: ./gradlew check coverage
+
+      - name: Upload coverage reports to Codecov
+        if: runner.os == 'Linux'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 repositories {
@@ -42,6 +43,23 @@ test {
         showCauses true
         showStackTraces true
         showStandardStreams = false
+    }
+
+    finalizedBy jacocoTestReport
+}
+
+task coverage(type: JacocoReport) {
+    sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
+    classDirectories.from files(sourceSets.main.output)
+    executionData.from files(jacocoTestReport.executionData)
+    afterEvaluate {
+        classDirectories.from files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['**/*.jar'])
+        })
+    }
+    reports {
+        html.required = true
+        xml.required = true
     }
 }
 


### PR DESCRIPTION
The reason that the branch name is `branch-A-CodeQuality` is to trigger the iP progress dashboard to turn green for this tag.

The feature was completed with a different branch name, `A-Code-Quality`.

In reality, this branch adds Codecov to the repo.